### PR TITLE
feat: add additional detection for bad JVM initial heap size

### DIFF
--- a/src/watchers/PasteWatcher.ts
+++ b/src/watchers/PasteWatcher.ts
@@ -105,7 +105,10 @@ class PasteWatcher extends BaseWatcher {
                             });
                         }
 
-                        if (response.body.match(/The specified size exceeds the maximum representable size/)) {
+                        if (
+                            response.body.match(/The specified size exceeds the maximum representable size/) ||
+                            response.body.match(/Could not reserve enough space for object heap/)
+                        ) {
                             errors.push({
                                 name: 'Allocating too much ram',
                                 value:


### PR DESCRIPTION
### Description of the Change

This adds an additional detection for the "Allocating too much ram" error. It catches the error from logs such as https://paste.atlauncher.com/view/6c1e09a4.
